### PR TITLE
some fixes

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -101,7 +101,7 @@ const onChange = async () => {
 
 const onChangeSearch = async () => {
   const searchInput: HTMLInputElement | null = document.querySelector('.searchInput');
-  if(searchInput){
+  if(searchInput && currMode === 'flashcard'){
     const inputVal = searchInput.value;
     if(inputVal !== ""){
       // then filter data

--- a/src/app.css
+++ b/src/app.css
@@ -76,6 +76,10 @@ input, select {
   font-family: inherit;
 }
 
+.searchInput {
+  width: 140px;
+}
+
 @media (prefers-color-scheme: light) {
   :root {
     color: #213547;

--- a/src/lib/DrawingCanvas.ts
+++ b/src/lib/DrawingCanvas.ts
@@ -52,10 +52,7 @@ export class DrawingCanvas {
       this.endClick(x, y);
     });
     
-    
-    // TODO: trying to match a character drawn by touch events (when testing
-    // with the device toolbar in dev tools) seems to cause the hanzi lookup WASM
-    // code to throw an unreachable error :/. so this feature on mobile is unusable atm.
+    // handle drawing via on touch
     canvasElement.addEventListener('touchmove', (e: TouchEvent) => {
       if(!this.clicking) return;
       e.preventDefault();
@@ -64,20 +61,6 @@ export class DrawingCanvas {
       this.lastTouchX = x;
       this.lastTouchY = y;
       this.dragClick(x, y);
-    });
-    
-    canvasElement.addEventListener('touchstart', (e: TouchEvent) => {
-      e.preventDefault();
-      const x = e.touches[0].pageX - canvasElement.getBoundingClientRect().left;
-      const y = e.touches[0].pageY - canvasElement.getBoundingClientRect().top;
-      this.startClick(x, y);
-    });
-    
-    canvasElement.addEventListener('touchend', (e: TouchEvent) => {
-      e.preventDefault();
-      this.endClick(this.lastTouchX, this.lastTouchY);
-      this.lastTouchX = -1;
-      this.lastTouchY = -1;
     });
     
     this.canvas = canvasElement;
@@ -90,6 +73,8 @@ export class DrawingCanvas {
     const ctx = this.canvas.getContext('2d');
     const width = this.canvas.width;
     const height = this.canvas.height;
+    this.rawStrokes = [];
+    this.currStroke = [];
     ctx.clearRect(0, 0, width, height);
     ctx.setLineDash([1, 1]);
     ctx.lineWidth = 0.5;


### PR DESCRIPTION
- fix mobile drawing (drawing via touch) for hanzi lookup w/ canvas
  - the only extra support needed for touch is the touchmove event. seems like pointerdown and pointerup work with touch already.
- fix bug with search when on quiz mode
  - when trying to use the search feature when on quiz mode, things broke. now we do a check to make sure search only works when in flashcard mode.
- make the toolbar a bit smaller (on mobile) by decreasing the width of the search input