### PR TITLE
Add caching for offline use

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,5 +10,21 @@
   <body>
     <div id="app"></div>
     <script type="module" src="/src/main.ts"></script>
+    <script>
+      // register our service worker to handle data fetching
+      // https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerContainer/register
+      if("serviceWorker" in navigator){
+        navigator.serviceWorker.register("/service_worker.js").then(
+          (registration) => {
+            console.log("service worker registration succeeded:", registration);
+          },
+          (err) => {
+            console.error(`service worker registration failed: ${err}`);
+          },
+        );
+      }else{
+        console.error("service workers are not supported");
+      }
+    </script>
   </body>
 </html>

--- a/public/service_worker.js
+++ b/public/service_worker.js
@@ -19,6 +19,7 @@ async function networkFirst(request){
     return networkResponse;
   }catch(err){
     // if fetch failed, possibly no internet? so try the cache for the data
+    console.log("failed to get data from url, trying cache");
     const cachedResponse = await caches.match(request);
     return cachedResponse || Response.error();
   }
@@ -39,8 +40,6 @@ async function precache(){
     "hanzi_lookup_worker.js",
     "hanzi_lookup.js",
     "hanzi_lookup_bg.wasm",
-    //".js", 
-    //"index-eafba863.css"
   ];
   console.log("precaching resources");
   const cache = await caches.open(cacheName);

--- a/service_worker.js
+++ b/service_worker.js
@@ -1,0 +1,53 @@
+// https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Guides/Offline_and_background_operation
+// https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers
+// https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Guides/Caching
+
+// service worker to help with caching JSON data used for the flashcards
+// we'll be using a "network first" strategy (try fetching from network the latest data first. if that fails, fall back to cache.)
+const cacheName = "flashcards_cache";
+
+async function networkFirst(request){
+  try {
+    console.log("got fetch request");
+    // get the latest data via fetch
+    const networkResponse = await fetch(request);
+    if(networkResponse.ok){
+      console.log("got data, adding to cache");
+      const cache = await caches.open(cacheName);
+      cache.put(request, networkResponse.clone());
+    }
+    return networkResponse;
+  }catch(err){
+    // if fetch failed, possibly no internet? so try the cache for the data
+    const cachedResponse = await caches.match(request);
+    return cachedResponse || Response.error();
+  }
+}
+
+// intercept fetch events so we can use our 'network first' strategy
+self.addEventListener("fetch", (evt) => {
+  const url = new URL(evt.request.url);
+  //if(url.pathname.match(/datasets\/.+.json/)){
+  evt.respondWith(networkFirst(evt.request));
+  //}
+});
+
+
+async function precache(){
+  const precachedResources = [
+    "/",
+    "hanzi_lookup_worker.js",
+    "hanzi_lookup.js",
+    "hanzi_lookup_bg.wasm",
+    //".js", 
+    //"index-eafba863.css"
+  ];
+  console.log("precaching resources");
+  const cache = await caches.open(cacheName);
+  return cache.addAll(precachedResources);
+}
+
+// make sure to cache all the needed static files in the service worker's install event
+self.addEventListener("install", (evt) => {
+  evt.waitUntil(precache());
+});

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -71,10 +71,7 @@ async function getJSONDataset(dataName: string){
     console.log(`getting data from: ${filename}`);
     return await fetch(filename);
   }catch(err){
-    // otherwise fall back to the file in /datasets. may be outdated
     console.log(err);
-    console.log('getting data from local dataset instead');
-    return await fetch(`datasets/${dataName}.json`);
   }
 }
 


### PR DESCRIPTION
This PR adds a service worker to cache resources like the JSON datasets so the app can be used offline! :D

These changes have already been deployed on the gh-pages branch. 

I tested this on my cellphone (Pixel 6a) by installing the current version of the app and turning on airplane mode to simulate being offline. 

It appears to work fine, although one thing to note is that each dataset must be viewed first (e.g. selected via the dropdown) in order for it to be cached.